### PR TITLE
official devices: Add support for Z00L/T

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1053,6 +1053,20 @@
         ]
     },
     {
+        "name": "Zenfone 2 Laser/Selfie",
+        "brand": "Asus",
+        "codename": "Z00T",
+        "supported_versions":[
+            {
+                "version_code":"pie",
+                "version_name":"Pie",
+                "maintainer_name": "Aayush Gupta (theimpulson)",
+                "maintainer_url": "https://forum.xda-developers.com/member.php?u=6042178",
+                "xda_thread": "https://forum.xda-developers.com/zenfone-2-laser/development/rom-aospextended-rom-v6-0-t3834642"
+            }
+        ]
+    },
+    {
         "name": "Zenfone 2 Laser",
         "brand": "Asus",
         "codename": "Z00L",
@@ -1063,6 +1077,20 @@
                 "maintainer_name": "Aayush Gupta (theimpulson)",
                 "maintainer_url": "https://forum.xda-developers.com/member.php?u=6042178",
                 "xda_thread": "https://forum.xda-developers.com/zenfone-2-laser/development/rom-aospextended-rom-v5-0-t3682935"
+            }
+        ]
+    },
+    {
+        "name": "Zenfone 2 Laser",
+        "brand": "Asus",
+        "codename": "Z00L",
+        "supported_versions":[
+            {
+                "version_code":"pie",
+                "version_name":"Pie",
+                "maintainer_name": "Aayush Gupta (theimpulson)",
+                "maintainer_url": "https://forum.xda-developers.com/member.php?u=6042178",
+                "xda_thread": "https://forum.xda-developers.com/zenfone-2-laser/development/rom-aospextended-rom-v6-0-t3834642"
             }
         ]
     },


### PR DESCRIPTION
What's working:
- Everything except bugs mentioned below

Bugs:
- No voice on VoLTE calls
- SELinux is permissive (boots enforcing with everything working but still want to keep permissive as the ZE601KL model requires sound patches which gives denials and none of the users submitted logs to fix it)
- Emergency calls without SIM don't work (None of the users care about it)
- LED doesn't support red color for now (Requires me to add support in hal)