### PR TITLE
Devices: Re-Add pie support for Moto G5s Plus

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -199,8 +199,14 @@
             "maintainer_name":"Keertesh",
             "maintainer_url":"https://forum.xda-developers.com/member.php?u=7686545",
             "xda_thread":"https://forum.xda-developers.com/moto-g5s-plus/development/rom-aospextended-rom-v5-1-t3737099"
+         },
+         {
+            "version_code":"pie",
+            "version_name":"Pie",
+            "maintainer_name":"Jorge Lucas",
+            "maintainer_url":"https://t.me/JorgeLucas",
+            "xda_thread":"https://forum.xda-developers.com/moto-g5s-plus/development/rom-aospextended-rom-v6-1-t3884053"
          }
-
       ]
    },
    {


### PR DESCRIPTION
I want to keep the AospExntend Pie again, old bugs fixed now.
These are the sources I use, with them I get fluid builds, good performance, bug free and crashes, functions like VoLTE, FMRadio, Miracast, DTV for Brazilian variant and other features work well.
I keep both versions of PixelExperience using them.

Vendor: https://github.com/Jorg3Lucas/android_vendor_motorola_sanders
Device: https://github.com/Jorg3Lucas/android_device_motorola_sanders
Kernel: https://github.com/Jorg3Lucas/android_kernel_motorola_msm8953